### PR TITLE
Update BatchWriteItem to look through entire slice of expectations ra…

### DIFF
--- a/batch_write_item.go
+++ b/batch_write_item.go
@@ -22,19 +22,15 @@ func (e *BatchWriteItemExpectation) WillReturns(res dynamodb.BatchWriteItemOutpu
 // BatchWriteItem - this func will be invoked when test running matching expectation with actual input
 func (e *MockDynamoDB) BatchWriteItem(input *dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error) {
 	if len(e.dynaMock.BatchWriteItemExpect) > 0 {
-		x := e.dynaMock.BatchWriteItemExpect[0] //get first element of expectation
-
-		if x.input != nil {
-			if !reflect.DeepEqual(x.input, input.RequestItems) {
-				return nil, fmt.Errorf("Expect input %+v but found input %+v", x.input, input.RequestItems)
+		for i, x := range e.dynaMock.BatchWriteItemExpect {
+			if x.input != nil {
+				if reflect.DeepEqual(x.input, input.RequestItems) {
+					e.dynaMock.BatchWriteItemExpect = append(e.dynaMock.BatchWriteItemExpect[:i], e.dynaMock.BatchWriteItemExpect[i:]...)
+					return x.output, nil
+				}
 			}
 		}
-
-		// delete first element of expectation
-		e.dynaMock.BatchWriteItemExpect = append(e.dynaMock.BatchWriteItemExpect[:0], e.dynaMock.BatchWriteItemExpect[1:]...)
-
-		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Batch Write Item Expectation Not Found")
+	return nil, fmt.Errorf("Batch Write Item Expectation Failed. Expected one of %+v to equal %+v", e.dynaMock.BatchWriteItemExpect, input.RequestItems)
 }


### PR DESCRIPTION
…ther than only checking in order

The `BatchWriteItem` method only works if requests are executed in the same order that expectations are added.

I'm using `BatchWriteItem` in concurrent operations and would like to be able to verify expectations regardless of the execution order.

This is a proposal to reslolve issue #15 