### PR TITLE
Adding BatchWriteItemWithContext

### DIFF
--- a/batch_write_item.go
+++ b/batch_write_item.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
@@ -21,6 +23,26 @@ func (e *BatchWriteItemExpectation) WillReturns(res dynamodb.BatchWriteItemOutpu
 
 // BatchWriteItem - this func will be invoked when test running matching expectation with actual input
 func (e *MockDynamoDB) BatchWriteItem(input *dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error) {
+	if len(e.dynaMock.BatchWriteItemExpect) > 0 {
+		x := e.dynaMock.BatchWriteItemExpect[0] //get first element of expectation
+
+		if x.input != nil {
+			if !reflect.DeepEqual(x.input, input.RequestItems) {
+				return nil, fmt.Errorf("Expect input %+v but found input %+v", x.input, input.RequestItems)
+			}
+		}
+
+		// delete first element of expectation
+		e.dynaMock.BatchWriteItemExpect = append(e.dynaMock.BatchWriteItemExpect[:0], e.dynaMock.BatchWriteItemExpect[1:]...)
+
+		return x.output, nil
+	}
+
+	return nil, fmt.Errorf("Batch Write Item Expectation Not Found")
+}
+
+// BatchWriteItemWithContext - this func will be invoked when test running matching expectation with actual input
+func (e *MockDynamoDB) BatchWriteItemWithContext(ctx aws.Context, input *dynamodb.BatchWriteItemInput, opt ...request.Option) (*dynamodb.BatchWriteItemOutput, error) {
 	if len(e.dynaMock.BatchWriteItemExpect) > 0 {
 		x := e.dynaMock.BatchWriteItemExpect[0] //get first element of expectation
 


### PR DESCRIPTION
This patch introduces BatchWriteItemWithContext API which
has same body of BatchWriteItem.

This is a proposal to resolve an issue https://github.com/gusaul/go-dynamock/issues/17