### PR TITLE
Upon error, return a pointer to a blank output object, not nil.

### DIFF
--- a/batch_get_item.go
+++ b/batch_get_item.go
@@ -28,7 +28,7 @@ func (e *MockDynamoDB) BatchGetItem(input *dynamodb.BatchGetItemInput) (*dynamod
 
 		if x.input != nil {
 			if !reflect.DeepEqual(x.input, input.RequestItems) {
-				return nil, fmt.Errorf("Expect input %+v but found input %+v", x.input, input.RequestItems)
+				return &dynamodb.BatchGetItemOutput{}, fmt.Errorf("Expect input %+v but found input %+v", x.input, input.RequestItems)
 			}
 		}
 
@@ -38,7 +38,7 @@ func (e *MockDynamoDB) BatchGetItem(input *dynamodb.BatchGetItemInput) (*dynamod
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Batch Get Item Expectation Not Found")
+	return &dynamodb.BatchGetItemOutput{}, fmt.Errorf("Batch Get Item Expectation Not Found")
 }
 
 // BatchGetItemWithContext - this func will be invoked when test running matching expectation with actual input
@@ -48,7 +48,7 @@ func (e *MockDynamoDB) BatchGetItemWithContext(ctx aws.Context, input *dynamodb.
 
 		if x.input != nil {
 			if !reflect.DeepEqual(x.input, input.RequestItems) {
-				return nil, fmt.Errorf("Expect input %+v but found input %+v", x.input, input.RequestItems)
+				return &dynamodb.BatchGetItemOutput{}, fmt.Errorf("Expect input %+v but found input %+v", x.input, input.RequestItems)
 			}
 		}
 
@@ -58,5 +58,5 @@ func (e *MockDynamoDB) BatchGetItemWithContext(ctx aws.Context, input *dynamodb.
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Batch Get Item With Context Expectation Not Found")
+	return &dynamodb.BatchGetItemOutput{}, fmt.Errorf("Batch Get Item With Context Expectation Not Found")
 }

--- a/batch_write_item.go
+++ b/batch_write_item.go
@@ -34,7 +34,7 @@ func (e *MockDynamoDB) BatchWriteItem(input *dynamodb.BatchWriteItemInput) (*dyn
 		}
 	}
 
-	return nil, fmt.Errorf("Batch Write Item Expectation Failed. Expected one of %+v to equal %+v", e.dynaMock.BatchWriteItemExpect, input.RequestItems)
+	return &dynamodb.BatchWriteItemOutput{}, fmt.Errorf("Batch Write Item Expectation Failed. Expected one of %+v to equal %+v", e.dynaMock.BatchWriteItemExpect, input.RequestItems)
 }
 
 // BatchWriteItemWithContext - this func will be invoked when test running matching expectation with actual input
@@ -44,7 +44,7 @@ func (e *MockDynamoDB) BatchWriteItemWithContext(ctx aws.Context, input *dynamod
 
 		if x.input != nil {
 			if !reflect.DeepEqual(x.input, input.RequestItems) {
-				return nil, fmt.Errorf("Expect input %+v but found input %+v", x.input, input.RequestItems)
+				return &dynamodb.BatchWriteItemOutput{}, fmt.Errorf("Expect input %+v but found input %+v", x.input, input.RequestItems)
 			}
 		}
 
@@ -54,5 +54,5 @@ func (e *MockDynamoDB) BatchWriteItemWithContext(ctx aws.Context, input *dynamod
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Batch Write Item Expectation Not Found")
+	return &dynamodb.BatchWriteItemOutput{}, fmt.Errorf("Batch Write Item Expectation Not Found")
 }

--- a/create_table.go
+++ b/create_table.go
@@ -32,13 +32,13 @@ func (e *MockDynamoDB) CreateTable(input *dynamodb.CreateTableInput) (*dynamodb.
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.CreateTableOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.keySchema != nil {
 			if !reflect.DeepEqual(x.keySchema, input.KeySchema) {
-				return nil, fmt.Errorf("Expect keySchema %+v but found keySchema %+v", x.keySchema, input.KeySchema)
+				return &dynamodb.CreateTableOutput{}, fmt.Errorf("Expect keySchema %+v but found keySchema %+v", x.keySchema, input.KeySchema)
 			}
 		}
 
@@ -48,5 +48,5 @@ func (e *MockDynamoDB) CreateTable(input *dynamodb.CreateTableInput) (*dynamodb.
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Create Table Expectation Not Found")
+	return &dynamodb.CreateTableOutput{}, fmt.Errorf("Create Table Expectation Not Found")
 }

--- a/delete_item.go
+++ b/delete_item.go
@@ -34,13 +34,13 @@ func (e *MockDynamoDB) DeleteItem(input *dynamodb.DeleteItemInput) (*dynamodb.De
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return &dynamodb.DeleteItemInput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.DeleteItemOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.key != nil {
 			if !reflect.DeepEqual(x.key, input.Key) {
-				return &dynamodb.DeleteItemInput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
+				return &dynamodb.DeleteItemOutput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
 			}
 		}
 
@@ -50,7 +50,7 @@ func (e *MockDynamoDB) DeleteItem(input *dynamodb.DeleteItemInput) (*dynamodb.De
 		return x.output, nil
 	}
 
-	return &dynamodb.DeleteItemInput{}, fmt.Errorf("Delete Item Expectation Not Found")
+	return &dynamodb.DeleteItemOutput{}, fmt.Errorf("Delete Item Expectation Not Found")
 }
 
 // DeleteItemWithContext - this func will be invoked when test running matching expectation with actual input
@@ -60,13 +60,13 @@ func (e *MockDynamoDB) DeleteItemWithContext(ctx aws.Context, input *dynamodb.De
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return &dynamodb.DeleteItemInput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.DeleteItemOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.key != nil {
 			if !reflect.DeepEqual(x.key, input.Key) {
-				return &dynamodb.DeleteItemInput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
+				return &dynamodb.DeleteItemOutput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
 			}
 		}
 
@@ -76,5 +76,5 @@ func (e *MockDynamoDB) DeleteItemWithContext(ctx aws.Context, input *dynamodb.De
 		return x.output, nil
 	}
 
-	return &dynamodb.DeleteItemInput{}, fmt.Errorf("Delete Item With Context Expectation Not Found")
+	return &dynamodb.DeleteItemOutput{}, fmt.Errorf("Delete Item With Context Expectation Not Found")
 }

--- a/delete_item.go
+++ b/delete_item.go
@@ -34,13 +34,13 @@ func (e *MockDynamoDB) DeleteItem(input *dynamodb.DeleteItemInput) (*dynamodb.De
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.DeleteItemInput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.key != nil {
 			if !reflect.DeepEqual(x.key, input.Key) {
-				return nil, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
+				return &dynamodb.DeleteItemInput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
 			}
 		}
 
@@ -50,7 +50,7 @@ func (e *MockDynamoDB) DeleteItem(input *dynamodb.DeleteItemInput) (*dynamodb.De
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Delete Item Expectation Not Found")
+	return &dynamodb.DeleteItemInput{}, fmt.Errorf("Delete Item Expectation Not Found")
 }
 
 // DeleteItemWithContext - this func will be invoked when test running matching expectation with actual input
@@ -60,13 +60,13 @@ func (e *MockDynamoDB) DeleteItemWithContext(ctx aws.Context, input *dynamodb.De
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.DeleteItemInput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.key != nil {
 			if !reflect.DeepEqual(x.key, input.Key) {
-				return nil, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
+				return &dynamodb.DeleteItemInput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
 			}
 		}
 
@@ -76,5 +76,5 @@ func (e *MockDynamoDB) DeleteItemWithContext(ctx aws.Context, input *dynamodb.De
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Delete Item With Context Expectation Not Found")
+	return &dynamodb.DeleteItemInput{}, fmt.Errorf("Delete Item With Context Expectation Not Found")
 }

--- a/describe_table.go
+++ b/describe_table.go
@@ -25,7 +25,7 @@ func (e *MockDynamoDB) DescribeTable(input *dynamodb.DescribeTableInput) (*dynam
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.DescribeTableOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
@@ -35,5 +35,5 @@ func (e *MockDynamoDB) DescribeTable(input *dynamodb.DescribeTableInput) (*dynam
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Describe Table Expectation Not Found")
+	return &dynamodb.DescribeTableOutput{}, fmt.Errorf("Describe Table Expectation Not Found")
 }

--- a/examples/example.go
+++ b/examples/example.go
@@ -46,13 +46,21 @@ func GetName(id string) (*string, error) {
 
 // GetName - example func using GetItem method
 func GetTransactGetItems(id string) error {
-	parameter := &dynamodb.TransactWriteItemsInput{}
+	parameter := &dynamodb.TransactWriteItemsInput{
+		TransactItems: []*dynamodb.TransactWriteItem{
+			{
+				Put: &dynamodb.Put{
+					TableName: aws.String("my_table"),
+				},
+			},
+		},
+	}
 
 	_, err := Dyna.Db.TransactWriteItems(parameter)
 
 	if err != nil {
-		 fmt.Print(err.Error())
-		 return err
+		fmt.Print(err.Error())
+		return err
 	}
 
 	return nil

--- a/get_item.go
+++ b/get_item.go
@@ -34,13 +34,13 @@ func (e *MockDynamoDB) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemO
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.GetItemOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.key != nil {
 			if !reflect.DeepEqual(x.key, input.Key) {
-				return nil, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
+				return &dynamodb.GetItemOutput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
 			}
 		}
 
@@ -50,7 +50,7 @@ func (e *MockDynamoDB) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemO
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Get Item Expectation Not Found")
+	return &dynamodb.GetItemOutput{}, fmt.Errorf("Get Item Expectation Not Found")
 }
 
 // GetItemWithContext - this func will be invoked when test running matching expectation with actual input
@@ -60,13 +60,13 @@ func (e *MockDynamoDB) GetItemWithContext(ctx aws.Context, input *dynamodb.GetIt
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.GetItemOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.key != nil {
 			if !reflect.DeepEqual(x.key, input.Key) {
-				return nil, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
+				return &dynamodb.GetItemOutput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
 			}
 		}
 
@@ -76,5 +76,5 @@ func (e *MockDynamoDB) GetItemWithContext(ctx aws.Context, input *dynamodb.GetIt
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Get Item With Context Expectation Not Found")
+	return &dynamodb.GetItemOutput{}, fmt.Errorf("Get Item With Context Expectation Not Found")
 }

--- a/put_item.go
+++ b/put_item.go
@@ -34,13 +34,13 @@ func (e *MockDynamoDB) PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemO
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.PutItemOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.item != nil {
 			if !reflect.DeepEqual(x.item, input.Item) {
-				return nil, fmt.Errorf("Expect item %+v but found item %+v", x.item, input.Item)
+				return &dynamodb.PutItemOutput{}, fmt.Errorf("Expect item %+v but found item %+v", x.item, input.Item)
 			}
 		}
 
@@ -50,7 +50,7 @@ func (e *MockDynamoDB) PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemO
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Put Item Expectation Not Found")
+	return &dynamodb.PutItemOutput{}, fmt.Errorf("Put Item Expectation Not Found")
 }
 
 // PutItemWithContext - this func will be invoked when test running matching expectation with actual input
@@ -60,13 +60,13 @@ func (e *MockDynamoDB) PutItemWithContext(ctx aws.Context, input *dynamodb.PutIt
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.PutItemOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.item != nil {
 			if !reflect.DeepEqual(x.item, input.Item) {
-				return nil, fmt.Errorf("Expect item %+v but found item %+v", x.item, input.Item)
+				return &dynamodb.PutItemOutput{}, fmt.Errorf("Expect item %+v but found item %+v", x.item, input.Item)
 			}
 		}
 
@@ -76,5 +76,5 @@ func (e *MockDynamoDB) PutItemWithContext(ctx aws.Context, input *dynamodb.PutIt
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Put Item With Context Expectation Not Found")
+	return &dynamodb.PutItemOutput{}, fmt.Errorf("Put Item With Context Expectation Not Found")
 }

--- a/query.go
+++ b/query.go
@@ -27,7 +27,7 @@ func (e *MockDynamoDB) Query(input *dynamodb.QueryInput) (*dynamodb.QueryOutput,
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.QueryOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
@@ -37,7 +37,7 @@ func (e *MockDynamoDB) Query(input *dynamodb.QueryInput) (*dynamodb.QueryOutput,
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Query Table Expectation Not Found")
+	return &dynamodb.QueryOutput{}, fmt.Errorf("Query Table Expectation Not Found")
 }
 
 // QueryWithContext - this func will be invoked when test running matching expectation with actual input
@@ -47,7 +47,7 @@ func (e *MockDynamoDB) QueryWithContext(ctx aws.Context, input *dynamodb.QueryIn
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.QueryOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
@@ -57,5 +57,5 @@ func (e *MockDynamoDB) QueryWithContext(ctx aws.Context, input *dynamodb.QueryIn
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Query Table With Context Expectation Not Found")
+	return &dynamodb.QueryOutput{}, fmt.Errorf("Query Table With Context Expectation Not Found")
 }

--- a/scan.go
+++ b/scan.go
@@ -27,7 +27,7 @@ func (e *MockDynamoDB) Scan(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, er
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.ScanOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
@@ -37,7 +37,7 @@ func (e *MockDynamoDB) Scan(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, er
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Scan Table Expectation Not Found")
+	return &dynamodb.ScanOutput{}, fmt.Errorf("Scan Table Expectation Not Found")
 }
 
 func (e *MockDynamoDB) ScanWithContext(ctx aws.Context, input *dynamodb.ScanInput, opts ...request.Option) (*dynamodb.ScanOutput, error) {
@@ -46,7 +46,7 @@ func (e *MockDynamoDB) ScanWithContext(ctx aws.Context, input *dynamodb.ScanInpu
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.ScanOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
@@ -56,5 +56,5 @@ func (e *MockDynamoDB) ScanWithContext(ctx aws.Context, input *dynamodb.ScanInpu
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Scan Table With Context Expectation Not Found")
+	return &dynamodb.ScanOutput{}, fmt.Errorf("Scan Table With Context Expectation Not Found")
 }

--- a/transact_write_items.go
+++ b/transact_write_items.go
@@ -34,7 +34,7 @@ func (e *MockDynamoDB) TransactWriteItems(input *dynamodb.TransactWriteItemsInpu
 
 		// compare lengths
 		if len(x.items) != len(input.TransactItems) {
-			return nil, fmt.Errorf("Expect items %+v but found items %+v", x.items, input.TransactItems)
+			return &dynamodb.TransactWriteItemsOutput{}, fmt.Errorf("Expect items %+v but found items %+v", x.items, input.TransactItems)
 		}
 
 		for i, item := range input.TransactItems {

--- a/transact_write_items.go
+++ b/transact_write_items.go
@@ -36,7 +36,7 @@ func (e *MockDynamoDB) TransactWriteItems(input *dynamodb.TransactWriteItemsInpu
 			}
 
 			if foundTable == false {
-				return nil, fmt.Errorf("Expect table %s not found", *x.table)
+				return &dynamodb.TransactWriteItemsOutput{}, fmt.Errorf("Expect table %s not found", *x.table)
 			}
 		}
 
@@ -48,7 +48,7 @@ func (e *MockDynamoDB) TransactWriteItems(input *dynamodb.TransactWriteItemsInpu
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Transact Write Items Table Expectation Not Found")
+	return &dynamodb.TransactWriteItemsOutput{}, fmt.Errorf("Transact Write Items Table Expectation Not Found")
 }
 
 func (e *MockDynamoDB) TransactWriteItemsWithContext(ctx aws.Context, input *dynamodb.TransactWriteItemsInput, opts ...request.Option) (*dynamodb.TransactWriteItemsOutput, error) {
@@ -67,7 +67,7 @@ func (e *MockDynamoDB) TransactWriteItemsWithContext(ctx aws.Context, input *dyn
 			}
 
 			if foundTable == false {
-				return nil, fmt.Errorf("Expect table %s not found", *x.table)
+				return &dynamodb.TransactWriteItemsOutput{}, fmt.Errorf("Expect table %s not found", *x.table)
 			}
 		}
 
@@ -79,5 +79,5 @@ func (e *MockDynamoDB) TransactWriteItemsWithContext(ctx aws.Context, input *dyn
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Transact Write Items Table With Context Expectation Not Found")
+	return &dynamodb.TransactWriteItemsOutput{}, fmt.Errorf("Transact Write Items Table With Context Expectation Not Found")
 }

--- a/update_item.go
+++ b/update_item.go
@@ -40,19 +40,19 @@ func (e *MockDynamoDB) UpdateItem(input *dynamodb.UpdateItemInput) (*dynamodb.Up
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.UpdateItemOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.key != nil {
 			if !reflect.DeepEqual(x.key, input.Key) {
-				return nil, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
+				return &dynamodb.UpdateItemOutput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
 			}
 		}
 
 		if x.attributeUpdates != nil {
 			if !reflect.DeepEqual(x.attributeUpdates, input.AttributeUpdates) {
-				return nil, fmt.Errorf("Expect key %+v but found key %+v", x.attributeUpdates, input.AttributeUpdates)
+				return &dynamodb.UpdateItemOutput{}, fmt.Errorf("Expect key %+v but found key %+v", x.attributeUpdates, input.AttributeUpdates)
 			}
 		}
 
@@ -62,7 +62,7 @@ func (e *MockDynamoDB) UpdateItem(input *dynamodb.UpdateItemInput) (*dynamodb.Up
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Update Item Expectation Not Found")
+	return &dynamodb.UpdateItemOutput{}, fmt.Errorf("Update Item Expectation Not Found")
 }
 
 // UpdateItemWithContext - this func will be invoked when test running matching expectation with actual input
@@ -72,19 +72,19 @@ func (e *MockDynamoDB) UpdateItemWithContext(ctx aws.Context, input *dynamodb.Up
 
 		if x.table != nil {
 			if *x.table != *input.TableName {
-				return nil, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+				return &dynamodb.UpdateItemOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
 			}
 		}
 
 		if x.key != nil {
 			if !reflect.DeepEqual(x.key, input.Key) {
-				return nil, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
+				return &dynamodb.UpdateItemOutput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
 			}
 		}
 
 		if x.attributeUpdates != nil {
 			if !reflect.DeepEqual(x.attributeUpdates, input.AttributeUpdates) {
-				return nil, fmt.Errorf("Expect key %+v but found key %+v", x.attributeUpdates, input.AttributeUpdates)
+				return &dynamodb.UpdateItemOutput{}, fmt.Errorf("Expect key %+v but found key %+v", x.attributeUpdates, input.AttributeUpdates)
 			}
 		}
 
@@ -94,5 +94,5 @@ func (e *MockDynamoDB) UpdateItemWithContext(ctx aws.Context, input *dynamodb.Up
 		return x.output, nil
 	}
 
-	return nil, fmt.Errorf("Update Item With Context Expectation Not Found")
+	return &dynamodb.UpdateItemOutput{}, fmt.Errorf("Update Item With Context Expectation Not Found")
 }


### PR DESCRIPTION
Fixes issue #34 