### PR TITLE
[TransactWriteItems] Table equality check to use pointers to avoid false-negative

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Muhammad Auliya
+Copyright (c) 2018 Flavio Deroo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
+Forked from https://github.com/gusaul/go-dynamock
+
 [![GoDoc](https://godoc.org/github.com/gusaul/go-dynamock?status.png)](https://godoc.org/github.com/gusaul/go-dynamock) [![Go Report Card](https://goreportcard.com/badge/github.com/gusaul/go-dynamock)](https://goreportcard.com/report/github.com/gusaul/go-dynamock) [![Build Status](https://travis-ci.com/gusaul/go-dynamock.svg?branch=master)](https://travis-ci.com/gusaul/go-dynamock)
 # go-dynamock
 Amazon Dynamo DB Mock Driver for Golang to Test Database Interactions
 
 ## Install
 ```
-go get github.com/gusaul/go-dynamock
+go get github.com/cgstag/go-dynamock
 ```
 
 ## Examples Usage
@@ -75,7 +77,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	dynamock "github.com/gusaul/go-dynamock"
+	dynamock "github.com/cgstag/go-dynamock"
 )
 
 var mock *dynamock.DynaMock
@@ -163,4 +165,4 @@ and will be treated cautiously
 
 ## License
 
-The [MIT License](https://github.com/gusaul/go-dynamock/blob/master/LICENSE)
+The [MIT License](https://github.com/cgstag/go-dynamock/blob/master/LICENSE)

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -1,7 +1,7 @@
 package examples
 
 import (
-	dynamock "github.com/gusaul/go-dynamock"
+	dynamock "github.com/cgstag/go-dynamock"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gusaul/go-dynamock
+module github.com/cgstag/go-dynamock
 
 go 1.15
 

--- a/transact_write_items.go
+++ b/transact_write_items.go
@@ -40,9 +40,9 @@ func (e *MockDynamoDB) TransactWriteItems(input *dynamodb.TransactWriteItemsInpu
 		for i, item := range input.TransactItems {
 			// comapre table name for each write transact item with `x.table`
 			if x.table != nil {
-				if (item.Update != nil && x.table != item.Update.TableName) ||
-					(item.Put != nil && x.table != item.Put.TableName) ||
-					(item.Delete != nil && x.table != item.Delete.TableName) {
+				if (item.Update != nil && *x.table != *item.Update.TableName) ||
+					(item.Put != nil && *x.table != *item.Put.TableName) ||
+					(item.Delete != nil && *x.table != *item.Delete.TableName) {
 					return &dynamodb.TransactWriteItemsOutput{}, fmt.Errorf("Expect table %s not found", *x.table)
 				}
 			}


### PR DESCRIPTION
This enables the client to have separate references of the tableName, with the same value rather than obliging to reuse the same reference.