### PR TITLE
Adding a test for both out of order and race condition, fixing GetItem for OOO

### DIFF
--- a/get_item.go
+++ b/get_item.go
@@ -29,28 +29,25 @@ func (e *GetItemExpectation) WillReturns(res dynamodb.GetItemOutput) *GetItemExp
 
 // GetItem - this func will be invoked when test running matching expectation with actual input
 func (e *MockDynamoDB) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
-	if len(e.dynaMock.GetItemExpect) > 0 {
-		x := e.dynaMock.GetItemExpect[0] //get first element of expectation
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
 
-		if x.table != nil {
-			if *x.table != *input.TableName {
-				return &dynamodb.GetItemOutput{}, fmt.Errorf("Expect table %s but found table %s", *x.table, *input.TableName)
+	for i, x := range e.dynaMock.GetItemExpect {
+		// If we the expectation doesn't contain a table or it matches the input match
+		if x.table == nil || reflect.DeepEqual(x.table, input.TableName) {
+			// If we got no keys on the expectation match on any input
+			if len(x.key) == 0 || reflect.DeepEqual(x.key, input.Key) {
+				end := i + 1
+				if len(e.dynaMock.GetItemExpect) == i {
+					end = i
+				}
+				e.dynaMock.GetItemExpect = append(e.dynaMock.GetItemExpect[:i], e.dynaMock.GetItemExpect[end:]...)
+				return x.output, nil
 			}
 		}
-
-		if x.key != nil {
-			if !reflect.DeepEqual(x.key, input.Key) {
-				return &dynamodb.GetItemOutput{}, fmt.Errorf("Expect key %+v but found key %+v", x.key, input.Key)
-			}
-		}
-
-		// delete first element of expectation
-		e.dynaMock.GetItemExpect = append(e.dynaMock.GetItemExpect[:0], e.dynaMock.GetItemExpect[1:]...)
-
-		return x.output, nil
 	}
 
-	return &dynamodb.GetItemOutput{}, fmt.Errorf("Get Item Expectation Not Found")
+	return &dynamodb.GetItemOutput{}, fmt.Errorf("Expected input with table name %+v and key %+v. Could not find within expectations", input.TableName, input.Key)
 }
 
 // GetItemWithContext - this func will be invoked when test running matching expectation with actual input

--- a/out_of_order_test.go
+++ b/out_of_order_test.go
@@ -1,0 +1,139 @@
+package dynamock
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+)
+
+// MyDynamo struct hold dynamodb connection
+type MyDynamo struct {
+	Db dynamodbiface.DynamoDBAPI
+}
+
+// Dyna - object from MyDynamo
+var Dyna *MyDynamo
+
+func TestOutOfOrderOperations_GetItem(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		Dyna := new(MyDynamo)
+		var mock *DynaMock
+		Dyna.Db, mock = New()
+
+		fooOut := dynamodb.GetItemOutput{
+			Item: map[string]*dynamodb.AttributeValue{
+				"name": {
+					S: aws.String("foo"),
+				},
+			},
+		}
+		mock.ExpectGetItem().ToTable("foo").WillReturns(fooOut)
+
+		barOut :=
+			dynamodb.GetItemOutput{
+				Item: map[string]*dynamodb.AttributeValue{
+					"name": {
+						S: aws.String("bar"),
+					},
+				},
+			}
+		mock.ExpectGetItem().ToTable("bar").WillReturns(barOut)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			foo, err := Dyna.Db.GetItem(
+				&dynamodb.GetItemInput{
+					Key: map[string]*dynamodb.AttributeValue{
+						"name": {
+							N: aws.String("foo"),
+						},
+					},
+					TableName: aws.String("foo"),
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(foo.Item["name"].S, fooOut.Item["name"].S) {
+				t.Errorf("foo failed expected %v got %v", foo.Item["name"].S, fooOut.Item["name"].S)
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bar, err := Dyna.Db.GetItem(
+				&dynamodb.GetItemInput{
+					Key: map[string]*dynamodb.AttributeValue{
+						"name": {
+							N: aws.String("bar"),
+						},
+					},
+					TableName: aws.String("bar"),
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(bar.Item["name"].S, barOut.Item["name"].S) {
+				t.Errorf("bar failed expected %v got %v", bar.Item["name"].S, barOut.Item["name"].S)
+			}
+		}()
+		wg.Wait()
+	}
+}
+
+func TestOutOfOrderOperations_GetItem_RaceCondition(t *testing.T) {
+	Dyna := new(MyDynamo)
+	var mock *DynaMock
+	Dyna.Db, mock = New()
+
+	fooOut := dynamodb.GetItemOutput{
+		Item: map[string]*dynamodb.AttributeValue{
+			"name": {
+				S: aws.String("foo"),
+			},
+		},
+	}
+	for i := 0; i < 10; i += 1 {
+		mock.ExpectGetItem().ToTable("foo").WillReturns(fooOut)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i += 1 {
+		go func() {
+			defer wg.Done()
+			foo, err := Dyna.Db.GetItem(
+				&dynamodb.GetItemInput{
+					Key: map[string]*dynamodb.AttributeValue{
+						"name": {
+							N: aws.String("foo"),
+						},
+					},
+					TableName: aws.String("foo"),
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(foo.Item["name"].S, fooOut.Item["name"].S) {
+				t.Errorf("foo failed expected %v got %v", foo.Item["name"].S, fooOut.Item["name"].S)
+			}
+		}()
+	}
+
+	wg.Wait()
+	if len(mock.GetItemExpect) != 0 {
+		t.Fatal("We should have exausted all the expectations")
+	}
+}

--- a/types.go
+++ b/types.go
@@ -1,6 +1,8 @@
 package dynamock
 
 import (
+	"sync"
+
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 )
@@ -10,6 +12,7 @@ type (
 	MockDynamoDB struct {
 		dynamodbiface.DynamoDBAPI
 		dynaMock *DynaMock
+		mutex    sync.Mutex
 	}
 
 	// DynaMock mock struct hold all expectation types


### PR DESCRIPTION
Hi! Thanks for the library!

I noticed there was a problem where if the test suite calls out of order from the order that the expectations were set then we'd get different behavior.

This works off of what was added for BatchWriteItem in #16. Note that this could be considered backwards incompatible because the errors that are returned are different, if we are considering the entire list of expectations then we can't necessarily return as nice of errors.

Additionally I suspected that we would be getting a race condition where expectations aren't properly removed. This is fixed by introducing a mutex.